### PR TITLE
CICD skips tests requiring scene runner

### DIFF
--- a/.github/workflows/gdunit4.yml
+++ b/.github/workflows/gdunit4.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           godot-version: '4.4.1'
           paths: 'res://test'
+          arguments: '--headless'

--- a/.github/workflows/gdunit4.yml
+++ b/.github/workflows/gdunit4.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           godot-version: '4.4.1'
           paths: 'res://test'
-          arguments: '--headless'
+          arguments: '--headless --ignoreHeadlessMode'

--- a/addons/gdUnit4/GdUnitRunner.cfg
+++ b/addons/gdUnit4/GdUnitRunner.cfg
@@ -1,1 +1,1 @@
-{"included":{"res://test/scripts/components/settings_test_window_mode.gd":[]},"server_port":31002,"skipped":{},"version":"1.0"}
+{"included":{"res://test/scripts/components/settings_test_window_mode.gd":["test__window_mode_fullscreen"]},"server_port":31002,"skipped":{},"version":"1.0"}

--- a/test/scripts/components/settings_test.gd
+++ b/test/scripts/components/settings_test.gd
@@ -27,6 +27,8 @@ func before(
 	do_skip : bool=DisplayServer.get_name().contains("headless"),
 	skip_reason : String="Cannot run scene runner tests in headless mode."
 ) -> void:
+	print("GET NAME: %s" % % DisplayServer.get_name())
+	print("DOES IT CONTAIN HEADLESS? : %s" % DisplayServer.get_name().contains("headless"))
 	test_dir = DirAccess.open(consts.TEST_SETTINGS_FOLDER_PATH)
 
 

--- a/test/scripts/components/settings_test.gd
+++ b/test/scripts/components/settings_test.gd
@@ -27,7 +27,7 @@ func before(
 	do_skip : bool=DisplayServer.get_name().contains("headless"),
 	skip_reason : String="Cannot run scene runner tests in headless mode."
 ) -> void:
-	print("GET NAME: %s" % % DisplayServer.get_name())
+	print("(SETTINGS_TEST) GET NAME: %s" % % DisplayServer.get_name())
 	print("DOES IT CONTAIN HEADLESS? : %s" % DisplayServer.get_name().contains("headless"))
 	test_dir = DirAccess.open(consts.TEST_SETTINGS_FOLDER_PATH)
 

--- a/test/scripts/components/settings_test_window_mode.gd
+++ b/test/scripts/components/settings_test_window_mode.gd
@@ -107,7 +107,6 @@ func _window_mode_picker(
 	var expected_dict : Dictionary = utilities.get_json_data(exp_output_path)
 	var actual_dict : Dictionary
 	var window_mode_options : OptionButton
-	var accept_button : Button
 	var save_changes_button : Button
 	
 	# Act

--- a/test/scripts/components/settings_test_window_mode.gd
+++ b/test/scripts/components/settings_test_window_mode.gd
@@ -21,13 +21,14 @@ var utilities : TestUtilities = TestUtilities.new()
 #endregion
 
 
-## before any test, skip the suite if the window is embedded
-## otherwise, set up DirAccess
+## before any test, set up DirAccess
 @warning_ignore('unused_parameter')
 func before(
 	do_skip : bool=DisplayServer.get_name().contains("headless"),
 	skip_reason : String="Cannot run scene runner tests in headless mode."
 ) -> void:
+	print("(SETTINGS_TEST_WINDOW_MODE) GET NAME: %s" % % DisplayServer.get_name())
+	print("DOES IT CONTAIN HEADLESS? : %s" % DisplayServer.get_name().contains("headless"))
 	test_dir = DirAccess.open(consts.TEST_SETTINGS_FOLDER_PATH)
 
 

--- a/test/scripts/components/settings_test_window_mode.gd
+++ b/test/scripts/components/settings_test_window_mode.gd
@@ -27,7 +27,7 @@ func before(
 	do_skip : bool=DisplayServer.get_name().contains("headless"),
 	skip_reason : String="Cannot run scene runner tests in headless mode."
 ) -> void:
-	print("(SETTINGS_TEST_WINDOW_MODE) GET NAME: %s" % % DisplayServer.get_name())
+	print("(SETTINGS_TEST_WINDOW_MODE) GET NAME: %s" % DisplayServer.get_name())
 	print("DOES IT CONTAIN HEADLESS? : %s" % DisplayServer.get_name().contains("headless"))
 	test_dir = DirAccess.open(consts.TEST_SETTINGS_FOLDER_PATH)
 


### PR DESCRIPTION
Previously the CICD was erroring on tests that used the GdUnit4 Scene Runner. This is because the tests ran in headless mode, preventing the tests from finding and interacting with the nodes by clicking on them.

The CICD will now skip tests requiring a display (ex: scene runner).